### PR TITLE
Add CS multilevel React app

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  env: { browser: true, es2021: true },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  settings: { react: { version: '18' } },
+  plugins: ['react', 'react-hooks'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+  },
+};

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# ggg
+# Computer Science Multilevel Map
+
+This project visualizes Prof. Denning's 12 areas of computer science. It is a React single-page app built with Vite and TypeScript. The knowledge base lives in `src/data/cs_map.json`.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Then open the printed local address in a browser. Use the search box to filter nodes and click a node to view details such as problems, people, venues and UVT connections.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Computer Science Multilevel Map</title>
+  </head>
+  <body class="overflow-hidden">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "cs-multilevel-map",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-force-graph": "^1.45.0",
+    "framer-motion": "^10.16.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "eslint": "^8.40.0",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,27 @@
+import React, { useState, useMemo } from 'react';
+import data from './data/cs_map.json';
+import { Node, Link } from './types';
+import Graph from './components/Graph';
+import SearchBar from './components/SearchBar';
+import DetailsPane from './components/DetailsPane';
+
+export default function App() {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<Node | undefined>();
+
+  const nodes = useMemo(() => data.nodes as Node[], []);
+  const links = useMemo(() => data.links as Link[], []);
+
+  return (
+    <div className="flex h-screen">
+      <SearchBar query={query} onChange={setQuery} />
+      <Graph
+        nodes={nodes}
+        links={links}
+        highlight={query}
+        onNodeClick={setSelected}
+      />
+      <DetailsPane node={selected} />
+    </div>
+  );
+}

--- a/src/components/DetailsPane.tsx
+++ b/src/components/DetailsPane.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Node } from '../types';
+
+interface Props {
+  node?: Node;
+}
+
+const tabs = ['overview', 'problems', 'people', 'venues', 'uvt'] as const;
+
+export default function DetailsPane({ node }: Props) {
+  const [active, setActive] = useState<(typeof tabs)[number]>('overview');
+
+  useEffect(() => {
+    setActive('overview');
+  }, [node]);
+
+  return (
+    <div className="w-80 border-l border-gray-200 p-4 overflow-y-auto">
+      <h2 className="mb-2 text-xl font-bold">
+        {node ? node.id : 'Select a node'}
+      </h2>
+      {node && (
+        <>
+          <div className="mb-2 space-x-2">
+            {tabs.map((t) => (
+              <button
+                key={t}
+                onClick={() => setActive(t)}
+                className={`text-sm ${active === t ? 'font-bold' : ''}`}
+              >
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </button>
+            ))}
+          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={active}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              className="text-sm"
+            >
+              {active === 'overview' && (
+                <pre>{JSON.stringify({
+                    activities: node.activities,
+                    dependencies: node.dependencies,
+                    influences: node.influences,
+                  }, null, 2)}</pre>
+              )}
+              {active === 'problems' && (
+                <div>
+                  {node.problems.map((p) => (
+                    <p key={p.title} className="mb-1">
+                      <strong>{p.title}</strong> ({p.status}) – {p.hint}
+                    </p>
+                  ))}
+                </div>
+              )}
+              {active === 'people' && <div>{node.people.join(', ')}</div>}
+              {active === 'venues' && <div>{node.venues.join(', ')}</div>}
+              {active === 'uvt' && (
+                <div>
+                  <p>
+                    <strong>People:</strong>{' '}
+                    {(node.uvt?.people ?? []).join(', ')}
+                  </p>
+                  <p>
+                    <strong>Courses:</strong>{' '}
+                    {(node.uvt?.courses ?? []).join(', ')}
+                  </p>
+                  <p>
+                    <strong>Research Groups:</strong>{' '}
+                    {(node.uvt?.researchGroups ?? []).join(', ')}
+                  </p>
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -1,0 +1,37 @@
+import React, { useRef, useEffect } from 'react';
+import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
+import { Node, Link } from '../types';
+
+interface Props {
+  nodes: Node[];
+  links: Link[];
+  highlight: string;
+  onNodeClick: (node: Node) => void;
+}
+
+export default function Graph({ nodes, links, highlight, onNodeClick }: Props) {
+  const ref = useRef<ForceGraphMethods>();
+
+  useEffect(() => {
+    ref.current?.d3Force('charge')?.strength(-300);
+  }, []);
+
+  return (
+    <ForceGraph2D
+      ref={ref}
+      graphData={{ nodes, links }}
+      nodeId="id"
+      nodeAutoColorBy="kind"
+      linkDirectionalParticles={1}
+      linkDirectionalParticleSpeed={0.005}
+      width={window.innerWidth - 320}
+      height={window.innerHeight}
+      nodeLabel="id"
+      onNodeClick={(node) => onNodeClick(node as Node)}
+      nodeVisibility={(node) =>
+        highlight === '' ||
+        (node as Node).id.toLowerCase().includes(highlight.toLowerCase())
+      }
+    />
+  );
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface Props {
+  query: string;
+  onChange: (value: string) => void;
+}
+
+export default function SearchBar({ query, onChange }: Props) {
+  return (
+    <div className="absolute left-4 top-4 z-10">
+      <input
+        value={query}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search..."
+        className="rounded border px-2 py-1 text-sm"
+      />
+    </div>
+  );
+}

--- a/src/data/cs_map.json
+++ b/src/data/cs_map.json
@@ -1,0 +1,189 @@
+{
+  "nodes": [
+    {
+      "id": "Algorithms and Data Structures",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Programming Languages", "Software Engineering"],
+      "influences": ["Artificial Intelligence & Robotics", "Graphics & Visualization"],
+      "problems": [
+        {"title": "P vs NP", "status": "open", "hint": "Are polynomial-time solutions as easy as verifications?"},
+        {"title": "Succinct data structures", "status": "research", "hint": "Near-optimal space with O(1) operations"}
+      ],
+      "people": ["Donald Knuth", "Robert Tarjan", "Eva Tardos"],
+      "venues": ["STOC", "FOCS", "SODA"],
+      "uvt": {
+        "people": ["Prof. Marius Ciară"],
+        "courses": ["Algorithms (year 2)"],
+        "researchGroups": ["DataScience@UVT"]
+      }
+    },
+    {
+      "id": "Programming Languages",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Theory of Computation"],
+      "influences": ["Software Engineering"],
+      "problems": [
+        {"title": "Type inference for dynamic languages", "status": "research", "hint": "Balance flexibility with safety"}
+      ],
+      "people": ["Grace Hopper", "Bjarne Stroustrup"],
+      "venues": ["POPL", "PLDI"],
+      "uvt": {
+        "courses": ["Programming Paradigms (year 2)"]
+      }
+    },
+    {
+      "id": "Architecture",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": [],
+      "influences": ["Operating Systems"],
+      "problems": [
+        {"title": "Energy-efficient processors", "status": "research", "hint": "More performance per watt"}
+      ],
+      "people": ["John Hennessy", "David Patterson"],
+      "venues": ["ISCA"],
+      "uvt": {}
+    },
+    {
+      "id": "Operating Systems",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Architecture"],
+      "influences": ["Networking"],
+      "problems": [
+        {"title": "Scalable scheduling", "status": "research", "hint": "Efficient resource allocation"}
+      ],
+      "people": ["Ken Thompson", "Dennis Ritchie"],
+      "venues": ["SOSP", "OSDI"],
+      "uvt": {}
+    },
+    {
+      "id": "Networking",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Operating Systems"],
+      "influences": [],
+      "problems": [
+        {"title": "Reliable wireless", "status": "research", "hint": "High bandwidth with low power"}
+      ],
+      "people": ["Vint Cerf"],
+      "venues": ["SIGCOMM"],
+      "uvt": {}
+    },
+    {
+      "id": "Databases",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Programming Languages"],
+      "influences": [],
+      "problems": [
+        {"title": "Scalable transaction processing", "status": "research", "hint": "Consistency with high throughput"}
+      ],
+      "people": ["Michael Stonebraker"],
+      "venues": ["SIGMOD"],
+      "uvt": {}
+    },
+    {
+      "id": "Artificial Intelligence & Robotics",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Algorithms and Data Structures"],
+      "influences": [],
+      "problems": [
+        {"title": "General intelligence", "status": "open", "hint": "Systems that learn and adapt broadly"}
+      ],
+      "people": ["Andrew Ng"],
+      "venues": ["ICML", "AAAI"],
+      "uvt": {
+        "researchGroups": ["AI@UVT"]
+      }
+    },
+    {
+      "id": "Numerical & Symbolic Computation",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Algorithms and Data Structures"],
+      "influences": [],
+      "problems": [
+        {"title": "Fast linear solvers", "status": "research", "hint": "Handle massive sparse matrices"}
+      ],
+      "people": ["Cleve Moler"],
+      "venues": ["SC"],
+      "uvt": {}
+    },
+    {
+      "id": "Software Engineering",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Programming Languages"],
+      "influences": ["Human-Computer Interaction"],
+      "problems": [
+        {"title": "Correctness proofs", "status": "research", "hint": "Verifiable large systems"}
+      ],
+      "people": ["Fred Brooks"],
+      "venues": ["ICSE"],
+      "uvt": {}
+    },
+    {
+      "id": "Human-Computer Interaction",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Software Engineering"],
+      "influences": [],
+      "problems": [
+        {"title": "Natural user interfaces", "status": "research", "hint": "Interaction beyond keyboard and mouse"}
+      ],
+      "people": ["Ben Shneiderman"],
+      "venues": ["CHI"],
+      "uvt": {}
+    },
+    {
+      "id": "Graphics & Visualization",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": ["Algorithms and Data Structures"],
+      "influences": [],
+      "problems": [
+        {"title": "Real-time global illumination", "status": "research", "hint": "High quality lighting at interactive rates"}
+      ],
+      "people": ["Jim Blinn"],
+      "venues": ["SIGGRAPH"],
+      "uvt": {}
+    },
+    {
+      "id": "Theory of Computation",
+      "kind": "area",
+      "activities": ["theory", "experiment", "design"],
+      "dependencies": [],
+      "influences": ["Programming Languages"],
+      "problems": [
+        {"title": "Quantum complexity classes", "status": "research", "hint": "What problems are efficiently solvable on quantum computers?"}
+      ],
+      "people": ["Alan Turing"],
+      "venues": ["LICS"],
+      "uvt": {}
+    }
+  ],
+  "links": [
+    {"source": "Algorithms and Data Structures", "target": "Programming Languages", "relation": "dependency"},
+    {"source": "Algorithms and Data Structures", "target": "Software Engineering", "relation": "dependency"},
+    {"source": "Algorithms and Data Structures", "target": "Artificial Intelligence & Robotics", "relation": "influence"},
+    {"source": "Algorithms and Data Structures", "target": "Graphics & Visualization", "relation": "influence"},
+    {"source": "Programming Languages", "target": "Theory of Computation", "relation": "dependency"},
+    {"source": "Programming Languages", "target": "Software Engineering", "relation": "influence"},
+    {"source": "Architecture", "target": "Operating Systems", "relation": "influence"},
+    {"source": "Operating Systems", "target": "Architecture", "relation": "dependency"},
+    {"source": "Operating Systems", "target": "Networking", "relation": "influence"},
+    {"source": "Networking", "target": "Operating Systems", "relation": "dependency"},
+    {"source": "Databases", "target": "Programming Languages", "relation": "dependency"},
+    {"source": "Artificial Intelligence & Robotics", "target": "Algorithms and Data Structures", "relation": "dependency"},
+    {"source": "Numerical & Symbolic Computation", "target": "Algorithms and Data Structures", "relation": "dependency"},
+    {"source": "Software Engineering", "target": "Programming Languages", "relation": "dependency"},
+    {"source": "Software Engineering", "target": "Human-Computer Interaction", "relation": "influence"},
+    {"source": "Human-Computer Interaction", "target": "Software Engineering", "relation": "dependency"},
+    {"source": "Graphics & Visualization", "target": "Algorithms and Data Structures", "relation": "dependency"},
+    {"source": "Theory of Computation", "target": "Programming Languages", "relation": "influence"}
+  ]
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,29 @@
+export interface Problem {
+  title: string;
+  status: string;
+  hint: string;
+}
+
+export interface UVTInfo {
+  people?: string[];
+  courses?: string[];
+  researchGroups?: string[];
+}
+
+export interface Node {
+  id: string;
+  kind: string;
+  activities: string[];
+  dependencies: string[];
+  influences: string[];
+  problems: Problem[];
+  people: string[];
+  venues: string[];
+  uvt?: UVTInfo;
+}
+
+export interface Link {
+  source: string;
+  target: string;
+  relation: string;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React 18 project with Vite and TypeScript
- configure Tailwind, ESLint and Prettier
- implement force-directed graph, search, and details pane
- supply dataset for all 12 Denning areas
- update instructions

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6846098f4dbc8324ab0decbbca2ab892